### PR TITLE
Add last_query function on database library

### DIFF
--- a/panada/drivers/database/mysql.php
+++ b/panada/drivers/database/mysql.php
@@ -769,6 +769,16 @@ class Drivers_database_mysql {
         // If there is an error then take note of it
         Library_error::database($str.'<br /><b>Query</b>: '.$query.'<br /><b>Backtrace</b>: '.$caller);
     }
+
+    /**
+     * Get latest executed query string
+     *
+     * @return string
+     */
+    public function last_query()
+    {
+    	return $this->last_query;
+    }
     
     /**
      * Get this db version

--- a/panada/drivers/database/postgresql.php
+++ b/panada/drivers/database/postgresql.php
@@ -716,6 +716,16 @@ class Drivers_database_postgresql {
         // If there is an error then take note of it
         Library_error::database($str.'<br /><b>Query</b>: '.$query.'<br /><b>Backtrace</b>: '.$caller);
     }
+
+    /**
+     * Get latest executed query string
+     *
+     * @return string
+     */
+    public function last_query()
+    {
+    	return $this->last_query;
+    }    
     
     /**
      * Get this db version

--- a/panada/drivers/database/sqlite.php
+++ b/panada/drivers/database/sqlite.php
@@ -718,6 +718,16 @@ class Drivers_database_sqlite {
         // If there is an error then take note of it
         Library_error::database($str.'<br /><b>Query</b>: '.$query.'<br /><b>Backtrace</b>: '.$caller);
     }
+
+    /**
+     * Get latest executed query string
+     *
+     * @return string
+     */
+    public function last_query()
+    {
+    	return $this->last_query;
+    }    
     
     /**
      * Get this db version


### PR DESCRIPTION
Salam pak, saya ikutan nimbrung boleh ya :)

Terinspirasi dari CodeIgniter, fungsi ini sangat berguna saat kita ingin memeriksa apakah query yang kita lakukan (entah itu menggunakan Active Record atau Query manual) sudah sesuai dengan yang kita harapkan atau belum, tentunya tanpa harus repot-repot mengaktifkan log di database server :-)

Sayangnya, fungsi ini hanya berjalan baik pada Query Manual dan Query Builder, sedangkan pada Active Record ada sedikit masalah.

Contoh penggunaan (Manual Query):

<pre>
$this->db->results("SELECT * FROM user");
echo $this->db->last_query();

$this->db->row("SELECT * FROM user");
echo $this->db->last_query();
</pre>

Akan menghasilkan: `SELECT * FROM user`

Query Builder:

<pre>
$this->db->select('username')->from('user')->find_all();
echo $this->db->last_query();

$this->db->select('username')->distinct()->from('user')->limit(10)->find_all();
echo $this->db->last_query();
</pre>

Akan menghasilkan: 
`SELECT username FROM user`
`SELECT DISTINCT username FROM user LIMIT 10`

Sedangkan jika menggunakan Active Record:

<pre>
$users = new Model_user();
$users->find();
$users->db->last_query();
</pre>

Nah, masalahnya properti `db` bersifat private, solusinya adalah dengan mengubah menjadi public, atau mungkin cara yang lebih manusiawi dengan membuat getter tambahan, tapi nanti nama fungsinya jadi ndak seragam. Atau mungkin bapak punya cara lain?

Ohya, sepertinya belum ada untuk `escape identifier` di library database ya pak? Kadang suka repot juga, terutama di Postgres :D
Kalau diijinkan nanti saya buatkan :)
