### PR TITLE
Fixing method param

### DIFF
--- a/panada/Resources/Uri.php
+++ b/panada/Resources/Uri.php
@@ -146,7 +146,7 @@ final class Uri
     {
 	$uriString = $this->path($segment);
     
-	if( isset($uriString) && ! empty($uriString) ) {
+	if( isset($uriString) ) {
     
 	    $requests = array_slice($this->path(), $segment);
     


### PR DESCRIPTION
If param method using integer 0, this param mean "empty" so param does not execute by panada
