### PR TITLE
exit with an error code in cli mode and re-format error message

### DIFF
--- a/panada/Resources/HttpException.php
+++ b/panada/Resources/HttpException.php
@@ -11,32 +11,43 @@
 namespace Resources;
 
 class HttpException extends \Exception
-{    
+{
     public function __construct($message = null, $code = 0, Exception $previous = null)
-    {    
+    {
         set_exception_handler( array($this, 'main') );
         parent::__construct($message, $code, $previous);
     }
-    
+
     public function __toString()
-    {    
+    {
         return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
     }
-    
+
     public function main($exception)
-    {    
-        self::outputError($exception->getMessage());
-    }
-    
-    public static function outputError($message = null)
     {
-	if(PHP_SAPI == 'cli')
-	    exit($message."\n");
-	
+        self::outputError($exception);
+    }
+
+    public static function outputError($exception)
+    {
+
+        if (PHP_SAPI == 'cli') {
+            echo $exception->getMessage()
+                ."\nFile: ".$exception->getFile()
+                    ." on line ".$exception->getLine()
+                ."\n\n".$exception->getTraceAsString()
+                ."\n";
+            // exit with an error code
+            exit(1);
+        }
+
         // Write the error to log file
-	@error_log('Error 404 Page Not Found: '.$_SERVER['REQUEST_URI']);
-        
+        @error_log('Error 404 Page Not Found: '.$_SERVER['REQUEST_URI']);
+
         header('HTTP/1.1 404 Not Found', true, 500);
-        \Resources\Controller::outputError('errors/404', array('message' => $message) );
+        \Resources\Controller::outputError(
+              'errors/404'
+            , array('message' => $exception->getMessage())
+            );
     }
 }


### PR DESCRIPTION
Changes:
- in cli mode, `exit(1)` exit with error code. `exit('message');` exit program normally
- re-format error message in cli mode.
- typos, strip trailing spaces
