### PR TITLE
Fix incorrect start line for error traces

### DIFF
--- a/panada/Resources/RunException.php
+++ b/panada/Resources/RunException.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Hendle every runtime code execution errors.
+ * Handle every runtime code execution errors.
  *
  * @author	Iskandar Soesman <k4ndar@yahoo.com>
  * @link	http://panadaframework.com/
@@ -75,8 +75,8 @@ class RunException extends \Exception
         $startIterate   = $line - 5;
         $endIterate     = $line + 5;
         
-        if($startIterate < 0)
-            $startIterate  = 0;
+        if($startIterate <= 0)
+            $startIterate = 1;
         
         if($endIterate > $totalLine)
             $endIterate = $totalLine;


### PR DESCRIPTION
Baris untuk error trace harus dimulai dari 1 dan bukan 0,
atau akan muncul Exception: `Undefined offset: 0` ketika error terjadi di 5 baris pertama file php. 

Tambahan fix typo.